### PR TITLE
feat(time-utilities): add defaults for DurationFormatter

### DIFF
--- a/packages/time-utilities/src/lib/DurationFormatter.ts
+++ b/packages/time-utilities/src/lib/DurationFormatter.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_UNITS } from './constants';
+
 /**
  * The supported time types
  */
@@ -31,7 +33,7 @@ const kTimeDurations: readonly [TimeTypes, number][] = [
  * @param assets The language assets
  */
 export class DurationFormatter {
-	public constructor(public units: DurationFormatAssetsTime) {}
+	public constructor(public units: DurationFormatAssetsTime = DEFAULT_UNITS) {}
 
 	public format(duration: number, precision = 7) {
 		const output: string[] = [];

--- a/packages/time-utilities/src/lib/constants.ts
+++ b/packages/time-utilities/src/lib/constants.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { DurationFormatAssetsTime, TimeTypes } from '..';
+import { DurationFormatAssetsTime, TimeTypes } from './DurationFormatter';
 
 export const enum Time {
 	Millisecond = 1,

--- a/packages/time-utilities/src/lib/constants.ts
+++ b/packages/time-utilities/src/lib/constants.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { DurationFormatAssetsTime, TimeTypes } from '..';
+
 export const enum Time {
 	Millisecond = 1,
 	Second = 1000,
@@ -78,3 +81,34 @@ export const cronTokens = {
 } as const;
 
 export const tokensRegex = new RegExp(Object.keys(cronTokens).join('|'), 'g');
+
+export const DEFAULT_UNITS: DurationFormatAssetsTime = {
+	[TimeTypes.Year]: {
+		1: 'year',
+		DEFAULT: 'years'
+	},
+	[TimeTypes.Month]: {
+		1: 'month',
+		DEFAULT: 'months'
+	},
+	[TimeTypes.Week]: {
+		1: 'week',
+		DEFAULT: 'weeks'
+	},
+	[TimeTypes.Day]: {
+		1: 'day',
+		DEFAULT: 'days'
+	},
+	[TimeTypes.Hour]: {
+		1: 'hour',
+		DEFAULT: 'hours'
+	},
+	[TimeTypes.Minute]: {
+		1: 'minute',
+		DEFAULT: 'minutes'
+	},
+	[TimeTypes.Second]: {
+		1: 'second',
+		DEFAULT: 'seconds'
+	}
+};

--- a/packages/time-utilities/tests/lib/duration/DurationFormatter.test.ts
+++ b/packages/time-utilities/tests/lib/duration/DurationFormatter.test.ts
@@ -1,38 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands, @typescript-eslint/naming-convention */
-import { DurationFormatAssetsTime, DurationFormatter, Time, TimeTypes } from '../../../src';
+import { DurationFormatter, Time } from '../../../src';
 
-const TIMES: DurationFormatAssetsTime = {
-	[TimeTypes.Year]: {
-		1: 'year',
-		DEFAULT: 'years'
-	},
-	[TimeTypes.Month]: {
-		1: 'month',
-		DEFAULT: 'months'
-	},
-	[TimeTypes.Week]: {
-		1: 'week',
-		DEFAULT: 'weeks'
-	},
-	[TimeTypes.Day]: {
-		1: 'day',
-		DEFAULT: 'days'
-	},
-	[TimeTypes.Hour]: {
-		1: 'hour',
-		DEFAULT: 'hours'
-	},
-	[TimeTypes.Minute]: {
-		1: 'minute',
-		DEFAULT: 'minutes'
-	},
-	[TimeTypes.Second]: {
-		1: 'second',
-		DEFAULT: 'seconds'
-	}
-};
-
-const formatter = new DurationFormatter(TIMES);
+const formatter = new DurationFormatter();
 
 function durationImpl(time: number, precision?: number) {
 	return formatter.format(time, precision);


### PR DESCRIPTION
It's sensible to have DurationFormatter default to en-US, since most users will not require language support.