### PR TITLE
fix(djs): modifying pages and messages outside of constructor

### DIFF
--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -56,7 +56,7 @@ export class PaginatedMessage {
 
 	public addPage(page: MessagePage) {
 		this.pages.push(page);
-		this.messages.push(typeof page === "function" ? null : page);
+		this.messages.push(typeof page === 'function' ? null : page);
 		return this;
 	}
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -43,17 +43,20 @@ export class PaginatedMessage {
 	}
 
 	public setPages(pages: MessagePage[]) {
-		this.pages = pages;
+		this.pages = [];
+		this.messages = [];
+		this.addPages(pages);
 		return this;
 	}
 
 	public addPages(pages: MessagePage[]) {
-		this.pages.push(...pages);
+		for (const page of pages) this.addPage(page);
 		return this;
 	}
 
 	public addPage(page: MessagePage) {
 		this.pages.push(page);
+		this.messages.push(typeof page === "function" ? null : page);
 		return this;
 	}
 


### PR DESCRIPTION
`addPage`, `addPages`, and `setPages` do not modify `messages`, which is needed when running `resolvePage`. This is a fix for this, as currently the only place that is properly modifying `messages` is in the constructor.