### PR TITLE
feat(discord.js-utilities): add checking index changes and documentation

### DIFF
--- a/packages/discord.js-utilities/src/lib/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/LazyPaginatedMessage.ts
@@ -1,10 +1,20 @@
-import { PaginatedMessage } from './PaginatedMessage';
+import { PaginatedMessage } from './PaginatedMessage.js';
 
+/**
+ * This is a LazyPaginatedMessage. Instead of resolving all pages that are functions on [[PaginatedMessage.run]] will resolve when requested.
+ */
 export class LazyPaginatedMessage extends PaginatedMessage {
+	/**
+	 * Only resolves the page corresponding with the handler's current index.
+	 */
 	public async resolvePagesOnStart() {
 		await this.resolvePage(this.index);
 	}
 
+	/**
+	 * Resolves the page corresponding with the given index. This also resolves the index's before and after the given index.
+	 * @param index The index to resolve. Defaults to handler's current index.
+	 */
 	public async resolvePage(index: number = this.index) {
 		await super.resolvePage(index - 1);
 		await super.resolvePage(index + 1);

--- a/packages/discord.js-utilities/src/lib/LazyPaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/LazyPaginatedMessage.ts
@@ -1,4 +1,4 @@
-import { PaginatedMessage } from './PaginatedMessage.js';
+import { PaginatedMessage } from './PaginatedMessage';
 
 /**
  * This is a LazyPaginatedMessage. Instead of resolving all pages that are functions on [[PaginatedMessage.run]] will resolve when requested.

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -18,6 +18,7 @@ import type { APIMessage, User, TextChannel, NewsChannel, Message, MessageReacti
  * @example
  * ```typescript
  * // To utilize actions you can use the IPaginatedMessageAction by implementing it into a class.
+ * // [[PaginatedMessage]] requires you to have the class initalized.
  *
  * class ForwardAction implements IPaginatedMessageAction {
  *   public id = '▶️';

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -18,7 +18,7 @@ import type { APIMessage, User, TextChannel, NewsChannel, Message, MessageReacti
  * @example
  * ```typescript
  * // To utilize actions you can use the IPaginatedMessageAction by implementing it into a class.
- * // [[PaginatedMessage]] requires you to have the class initalized.
+ * // [[PaginatedMessage]] requires you to have the class initialized using `new`.
  *
  * class ForwardAction implements IPaginatedMessageAction {
  *   public id = '▶️';

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -1,23 +1,23 @@
 import type { APIMessage, User, TextChannel, NewsChannel, Message, MessageReaction, ReactionCollector } from 'discord.js';
 
 /**
- * This is a PaginatedMessage, a very powerful tool to paginate messages (usually embeds).
- * The developer must either use this class directly or extend it.
+ * This is a [[PaginatedMessage]], a utility to paginate messages (usually embeds).
+ * You must either use this class directly or extend it.
  *
- * PaginatedMessage uses actions, these are essentially reaction emojis, when triggered run the said action.
- * The developer can utilize their own actions or can use the [[PaginatedMessage.defaultActions]].
+ * [[PaginatedMessage]] uses actions, these are essentially reaction emojis, when triggered run the said action.
+ * You can utilize your own actions, or you can use the [[PaginatedMessage.defaultActions]].
  * [[PaginatedMessage.defaultActions]] is also static so you can modify these directly.
  *
- * PaginatedMessage also uses pages, these are simply an {@link https://discord.js.org/#/docs/main/stable/class/APIMessage APIMessage}.
+ * [[PaginatedMessage]] also uses pages, these are simply {@link https://discord.js.org/#/docs/main/stable/class/APIMessage APIMessages}.
  *
  * @example
  * ```typescript
  * const handler = new PaginatedMessage();
- * ````
+ * ```
  *
  * @example
  * ```typescript
- * // To utilize actions you can use the [[IPaginatedMessageAction]] by implementing it into a class.
+ * // To utilize actions you can use the IPaginatedMessageAction by implementing it into a class.
  *
  * class ForwardAction implements IPaginatedMessageAction {
  *   public id = '▶️';
@@ -41,7 +41,7 @@ import type { APIMessage, User, TextChannel, NewsChannel, Message, MessageReacti
  */
 export class PaginatedMessage {
 	/**
-	 * The pages to be later converted to [[PaginatedMessage.messages]]
+	 * The pages to be converted to [[PaginatedMessage.messages]]
 	 */
 	public pages: MessagePage[];
 
@@ -65,6 +65,10 @@ export class PaginatedMessage {
 	 */
 	public idle = 20 * 1000;
 
+	/**
+	 * Constructor for the [[PaginatedMessage]] class
+	 * @param __namedParameters The [[PaginatedMessageOptions]] for this instance of the [[PaginatedMessage]] class
+	 */
 	public constructor({ pages, actions = PaginatedMessage.defaultActions }: PaginatedMessageOptions = {}) {
 		this.pages = pages ?? [];
 
@@ -148,7 +152,7 @@ export class PaginatedMessage {
 	}
 
 	/**
-	 * This executes the PaginatedMessage and sends the pages corresponding with [[PaginatedMessage.index]].
+	 * This executes the [[PaginatedMessage]] and sends the pages corresponding with [[PaginatedMessage.index]].
 	 * The handler will start collecting reactions and running actions once all actions have been reacted to the message.
 	 * @param author The author to validate.
 	 * @param channel The channel to use.

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -93,7 +93,7 @@ export class PaginatedMessage {
 
 				const page = await this.resolvePage();
 
-				await response.edit(page!);
+				if (!action.disabledResponseEdit) await response.edit(page!);
 			})
 			.on('end', () => response.reactions.removeAll());
 
@@ -135,7 +135,7 @@ export class PaginatedMessage {
 
 						const i = Number(responseMessage.content) - 1;
 
-						if (!Number.isNaN(i) && handler.pages[i]) handler.index = i;
+						if (!isNaN(i) && handler.pages[i]) handler.index = i;
 					}
 				}
 			}
@@ -162,6 +162,7 @@ export class PaginatedMessage {
 		},
 		{
 			id: '⏹️',
+			disabledResponseEdit: true,
 			run: async ({ response, collector }) => {
 				await response!.reactions.removeAll();
 				collector!.stop();
@@ -172,6 +173,7 @@ export class PaginatedMessage {
 
 export interface IPaginatedMessageAction {
 	id: string;
+	disabledResponseEdit?: boolean;
 	run(context: PaginatedMessageActionContext): Awaited<unknown>;
 }
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -179,6 +179,7 @@ export class PaginatedMessage {
 				await reaction.users.remove(user);
 
 				const action = (this.actions.get(reaction.emoji.identifier) ?? this.actions.get(reaction.emoji.name))!;
+				const previousIndex = this.index;
 
 				await action.run({
 					handler: this,
@@ -188,9 +189,11 @@ export class PaginatedMessage {
 					collector
 				});
 
-				const page = await this.resolvePage();
+				if (previousIndex !== this.index) {
+					const page = await this.resolvePage();
 
-				if (!action.disabledResponseEdit) await response.edit(page!);
+					await response.edit(page!);
+				}
 			})
 			.on('end', () => response.reactions.removeAll());
 
@@ -272,7 +275,6 @@ export class PaginatedMessage {
 		},
 		{
 			id: '⏹️',
-			disabledResponseEdit: true,
 			run: async ({ response, collector }) => {
 				await response!.reactions.removeAll();
 				collector!.stop();
@@ -307,7 +309,6 @@ export class PaginatedMessage {
  */
 export interface IPaginatedMessageAction {
 	id: string;
-	disabledResponseEdit?: boolean;
 	run(context: PaginatedMessageActionContext): Awaited<unknown>;
 }
 

--- a/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
+++ b/packages/discord.js-utilities/src/lib/PaginatedMessage.ts
@@ -1,13 +1,68 @@
 import type { APIMessage, User, TextChannel, NewsChannel, Message, MessageReaction, ReactionCollector } from 'discord.js';
 
+/**
+ * This is a PaginatedMessage, a very powerful tool to paginate messages (usually embeds).
+ * The developer must either use this class directly or extend it.
+ *
+ * PaginatedMessage uses actions, these are essentially reaction emojis, when triggered run the said action.
+ * The developer can utilize their own actions or can use the [[PaginatedMessage.defaultActions]].
+ * [[PaginatedMessage.defaultActions]] is also static so you can modify these directly.
+ *
+ * PaginatedMessage also uses pages, these are simply an {@link https://discord.js.org/#/docs/main/stable/class/APIMessage APIMessage}.
+ *
+ * @example
+ * ```typescript
+ * const handler = new PaginatedMessage();
+ * ````
+ *
+ * @example
+ * ```typescript
+ * // To utilize actions you can use the [[IPaginatedMessageAction]] by implementing it into a class.
+ *
+ * class ForwardAction implements IPaginatedMessageAction {
+ *   public id = '▶️';
+ *
+ *   public run({ handler }) {
+ *     if (handler.index !== handler.pages.length - 1) ++handler.index;
+ *   }
+ * }
+ *
+ * // You can also give the object directly.
+ *
+ * const StopAction: IPaginatedMessageAction {
+ *   id: '⏹️',
+ *   disableResponseEdit: true,
+ *   run: ({ response, collector }) => {
+ *     await response!.reactions.removeAll();
+ *     collector!.stop();
+ *   }
+ * }```
+ *
+ */
 export class PaginatedMessage {
+	/**
+	 * The pages to be later converted to [[PaginatedMessage.messages]]
+	 */
 	public pages: MessagePage[];
+
+	/**
+	 * The pages which were converted from [[PaginatedMessage.pages]]
+	 */
 	public messages: (APIMessage | null)[] = [];
 
+	/**
+	 * The actions which are to be used.
+	 */
 	public actions = new Map<string, IPaginatedMessageAction>();
 
+	/**
+	 * The handler's current page/message index.
+	 */
 	public index = 0;
 
+	/**
+	 * The amount of time to idle before the paginator is closed. Defaults to `20 * 1000`.
+	 */
 	public idle = 20 * 1000;
 
 	public constructor({ pages, actions = PaginatedMessage.defaultActions }: PaginatedMessageOptions = {}) {
@@ -17,31 +72,55 @@ export class PaginatedMessage {
 		for (const action of actions) this.actions.set(action.id, action);
 	}
 
+	/**
+	 * Sets the handler's current page/message index.
+	 * @param index The number to set the index to.
+	 */
 	public setIndex(index: number) {
 		this.index = index;
 		return this;
 	}
 
+	/**
+	 * Sets the amount of time to idle before the paginator is closed.
+	 * @param idle The number to set the idle to.
+	 */
 	public setIdle(idle: number) {
 		this.idle = idle;
 		return this;
 	}
 
+	/**
+	 * Clears all current actions and sets them. The order given is the order they will be used.
+	 * @param actions The actions to set.
+	 */
 	public setActions(actions: IPaginatedMessageAction[]) {
 		this.actions.clear();
 		return this.addActions(actions);
 	}
 
+	/**
+	 * Adds actions to the existing ones. The order given is the order they will be used.
+	 * @param actions The actions to add.
+	 */
 	public addActions(actions: IPaginatedMessageAction[]) {
 		for (const action of actions) this.addAction(action);
 		return this;
 	}
 
+	/**
+	 * Adds an action to the existing ones. This will be added as the last action.
+	 * @param action The action to add.
+	 */
 	public addAction(action: IPaginatedMessageAction) {
 		this.actions.set(action.id, action);
 		return this;
 	}
 
+	/**
+	 * Clears all current pages and messages and sets them. The order given is the order they will be used.
+	 * @param pages The pages to set.
+	 */
 	public setPages(pages: MessagePage[]) {
 		this.pages = [];
 		this.messages = [];
@@ -49,17 +128,31 @@ export class PaginatedMessage {
 		return this;
 	}
 
+	/**
+	 * Add pages to the existing ones. The order given is the order they will be used.
+	 * @param pages The pages to add.
+	 */
 	public addPages(pages: MessagePage[]) {
 		for (const page of pages) this.addPage(page);
 		return this;
 	}
 
+	/**
+	 * Adds a page to the existing ones. This will be added as the last page.
+	 * @param page The page to add.
+	 */
 	public addPage(page: MessagePage) {
 		this.pages.push(page);
 		this.messages.push(typeof page === 'function' ? null : page);
 		return this;
 	}
 
+	/**
+	 * This executes the PaginatedMessage and sends the pages corresponding with [[PaginatedMessage.index]].
+	 * The handler will start collecting reactions and running actions once all actions have been reacted to the message.
+	 * @param author The author to validate.
+	 * @param channel The channel to use.
+	 */
 	public async run(author: User, channel: TextChannel | NewsChannel) {
 		await this.resolvePagesOnRun();
 
@@ -100,10 +193,17 @@ export class PaginatedMessage {
 		return this;
 	}
 
+	/**
+	 * This function is executed on [[PaginatedMessage.run]]. This is an extendable method.
+	 */
 	public async resolvePagesOnRun() {
 		for (let i = 0; i < this.pages.length; i++) await this.resolvePage(i);
 	}
 
+	/**
+	 * This function is executed whenever an action is triggered and resolved.
+	 * @param index The index to resolve.
+	 */
 	public async resolvePage(index: number = this.index) {
 		const page = this.pages[index];
 		// @ts-expect-error 2349
@@ -111,12 +211,18 @@ export class PaginatedMessage {
 		return this.messages[index];
 	}
 
+	/**
+	 * This clones the current handler into a new instance.
+	 */
 	public clone() {
 		const clone = new PaginatedMessage({ pages: this.pages, actions: [] }).setIndex(this.index).setIdle(this.idle);
 		clone.actions = this.actions;
 		return clone;
 	}
 
+	/**
+	 * The default actions of this handler.
+	 */
 	public static defaultActions: IPaginatedMessageAction[] = [
 		{
 			id: '🔢',
@@ -171,12 +277,39 @@ export class PaginatedMessage {
 	];
 }
 
+/**
+ * @example
+ * ```typescript
+ * // To utilize actions you can use the [[IPaginatedMessageAction]] by implementing it into a class.
+ *
+ * class ForwardAction implements IPaginatedMessageAction {
+ *   public id = '▶️';
+ *
+ *   public run({ handler }) {
+ *     if (handler.index !== handler.pages.length - 1) ++handler.index;
+ *   }
+ * }
+ *
+ * // You can also give the object directly.
+ *
+ * const StopAction: IPaginatedMessageAction {
+ *   id: '⏹️',
+ *   disableResponseEdit: true,
+ *   run: ({ response, collector }) => {
+ *     await response!.reactions.removeAll();
+ *     collector!.stop();
+ *   }
+ * }```
+ */
 export interface IPaginatedMessageAction {
 	id: string;
 	disabledResponseEdit?: boolean;
 	run(context: PaginatedMessageActionContext): Awaited<unknown>;
 }
 
+/**
+ * The context to be used in [[IPaginatedMessageAction]].
+ */
 export interface PaginatedMessageActionContext {
 	handler: PaginatedMessage;
 	author: User;
@@ -190,6 +323,28 @@ export interface PaginatedMessageOptions {
 	actions?: IPaginatedMessageAction[];
 }
 
+/**
+ * The pages that are used for [[PaginatedMessage.pages]]
+ *
+ * Pages can be either an {@link https://discord.js.org/#/docs/main/stable/class/APIMessage APIMessage} directly,
+ * or an awaited function which returns an {@link https://discord.js.org/#/docs/main/stable/class/APIMessage APIMessage}.
+ *
+ * @example
+ * ```typescript
+ * // Direct usage as an APIMessage
+ *
+ * new APIMessage(message.channel, {
+ *   context: 'Test content!',
+ * });
+ *
+ * // An awaited function. This function also passes index, pages, and handler.
+ *
+ * (index, pages) =>
+ *   new APIMessage(message.channel, {
+ *     embed: new MessageEmbed().setFooter(`Page ${index + 1} / ${pages.length}`)
+ *   });
+ * ```
+ */
 export type MessagePage = ((index: number, pages: MessagePage[], handler: PaginatedMessage) => Awaited<APIMessage>) | APIMessage;
 
 type Awaited<T> = PromiseLike<T> | T;


### PR DESCRIPTION
This PR implements a feature `disableResponseEdit` to the `IPaginatedMessageAction`. This enables developers to have an action only execute without editing the page to the current index.

This PR also includes documentation for the utility as a whole. Some of which was not written the best, so if you think something should be different go right ahead and suggest it.