### PR TITLE
fix(discord.js-utilities): improve MessagePrompter typings

### DIFF
--- a/packages/discord.js-utilities/src/lib/MessagePrompter/MessagePrompter.ts
+++ b/packages/discord.js-utilities/src/lib/MessagePrompter/MessagePrompter.ts
@@ -1,6 +1,11 @@
 import type { CollectorFilter, DMChannel, EmojiResolvable, Message, NewsChannel, TextChannel, User } from 'discord.js';
 import { Constructor, MessagePrompterMessage, MessagePrompterStrategies } from './constants';
-import type { IMessagePrompterExplicitConfirmReturn, IMessagePrompterExplicitMessageReturn, IMessagePrompterExplicitNumberReturn, IMessagePrompterExplicitReturnBase } from './ExplicitReturnTypes';
+import type {
+	IMessagePrompterExplicitConfirmReturn,
+	IMessagePrompterExplicitMessageReturn,
+	IMessagePrompterExplicitNumberReturn,
+	IMessagePrompterExplicitReturnBase
+} from './ExplicitReturnTypes';
 import { MessagePrompterBaseStrategy } from './strategies/MessagePrompterBaseStrategy';
 import { MessagePrompterConfirmStrategy } from './strategies/MessagePrompterConfirmStrategy';
 import { MessagePrompterMessageStrategy } from './strategies/MessagePrompterMessageStrategy';
@@ -114,7 +119,7 @@ export class MessagePrompter<S extends MessagePrompterStrategies = MessagePrompt
 	 */
 	public run(
 		channel: TextChannel | NewsChannel | DMChannel,
-		authorOrFilter: User | CollectorFilter,
+		authorOrFilter: User | CollectorFilter
 	): S extends keyof StrategyReturns ? Promise<StrategyReturns[S]> : never {
 		return this.strategy.run(channel, authorOrFilter) as S extends keyof StrategyReturns ? Promise<StrategyReturns[S]> : never;
 	}


### PR DESCRIPTION
`MessagePrompter.run` used to be poorly typed, with `unknown`, which prevented users to use `.catch()` or `.then()`. With a simple generic, it was quite easy to deduce the appropriate return type.
The idea of the interfaces to simplify the return types (rather than having a big nested ternary expression) comes from @kyranet

Because the default strategy of the MessagePrompter is the base strategy, I had to cast the return type. Maybe this can be improved